### PR TITLE
getMatch now also fetches the timeline of the match and adds it as a …

### DIFF
--- a/api/player/index.js
+++ b/api/player/index.js
@@ -11,6 +11,7 @@ app.get('*', async (req, res) => {
         // Loop through the general game data from the player, and get specific data for each one and put it in the player object.
         for (const [index, match] of player.matchHistory.matches.entries()) {
             player.matchHistory.matches[index] = await getMatch(match.gameId);
+            delete player.matchHistory.matches[index].timeline // Remove the timeline, as this endpoint is for displaying "thumbnails" of matches.
         }
         let endTime = Date.now() // benchmarking time
         console.log((endTime - startTime) / 1000); // benchmarking time


### PR DESCRIPTION
…property to the match. The get player by name route does NOT return the timeline for every match, as that would make the response body over 1MB of data.